### PR TITLE
Fix disagreement in cmlModule module spec and init

### DIFF
--- a/plugins/module_utils/cml_utils.py
+++ b/plugins/module_utils/cml_utils.py
@@ -39,7 +39,7 @@ class cmlModule(object):
         self.status = None
         self.url = None
         self.params['force_basic_auth'] = True
-        self.user = self.params['user']
+        self.user = self.params['username']
         self.password = self.params['password']
         self.host = self.params['host']
         self.timeout = self.params['timeout']

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -92,7 +92,7 @@ EXAMPLES = r"""
     - name: Create the lab
       cisco.cml.cml_lab:
         host: "{{ cml_host }}"
-        user: "{{ cml_username }}"
+        username: "{{ cml_username }}"
         password: "{{ cml_password }}"
         lab: "{{ cml_lab }}"
         state: present

--- a/plugins/modules/cml_lab_facts.py
+++ b/plugins/modules/cml_lab_facts.py
@@ -52,7 +52,7 @@ EXAMPLES = r"""
     - name: Get facts about a lab in CML
       cisco.cml.cml_lab_facts:
         host: "{{ cml_host }}"
-        user: "{{ cml_username }}"
+        username: "{{ cml_username }}"
         password: "{{ cml_password }}"
         lab: "{{ cml_lab }}"
       register: results

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -106,7 +106,7 @@ EXAMPLES = r"""
       cisco.cml.cml_node:
         name: "{{ inventory_hostname }}"
         host: "{{ cml_host }}"
-        user: "{{ cml_username }}"
+        username: "{{ cml_username }}"
         password: "{{ cml_password }}"
         lab: "{{ cml_lab }}"
         state: started

--- a/plugins/modules/cml_users.py
+++ b/plugins/modules/cml_users.py
@@ -84,7 +84,7 @@ EXAMPLES = r"""
     - name: Add users to the CML instance
       cisco.cml.cml_users:
         host: "{{ cml_host }}"
-        user: "{{ cml_username }}"
+        username: "{{ cml_username }}"
         password: "{{ cml_password }}"
         name: "first_user"
         user_pass: "password"
@@ -94,7 +94,7 @@ EXAMPLES = r"""
     - name: Remove users from the CML instance
       cisco.cml.cml_users:
         host: "{{ cml_host }}"
-        user: "{{ cml_username }}"
+        username: "{{ cml_username }}"
         password: "{{ cml_password }}"
         name: "old_user"
         state: "absent"


### PR DESCRIPTION
Simple fix for bug in https://github.com/CiscoDevNet/ansible-cml/issues/38

Also updated all the examples in the modules, as the continued use of the 'user' alias instead of 'username' seems to be why this might work and went unnoticed.


From: https://github.com/CiscoDevNet/ansible-cml/pull/39