### PR TITLE
check_mode support for cml_lab and cml_node modules

### DIFF
--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -137,6 +137,8 @@ def run_module():
 
     if cml.params['state'] in ['present', 'started']:
         if lab is None:
+            if module.check_mode:
+                module.exit_json(changed=True)
             # create the lab
             if cml.params['topology']:
                 lab = cml.client.import_lab(cml.params['topology'], title=cml.params['lab'])
@@ -154,11 +156,15 @@ def run_module():
             lab.title = cml.params['lab']
             cml.result['changed'] = True
         elif lab.state() == "STOPPED" and cml.params['state'] == 'started':
+            if module.check_mode:
+                module.exit_json(changed=True)
             # start existing stopped lab
             lab.start(wait=cml.params['wait'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'absent':
         if lab:
+            if module.check_mode:
+                module.exit_json(changed=True)
             # remove existing lab
             cml.result['changed'] = True
             if lab.state() == "STARTED":
@@ -170,12 +176,16 @@ def run_module():
     elif cml.params['state'] == 'stopped':
         if lab:
             if lab.state() == "STARTED":
+                if module.check_mode:
+                    module.exit_json(changed=True)
                 # stop existing running lab
                 cml.result['changed'] = True
                 lab.stop(wait=True)
     elif cml.params['state'] == 'wiped':
         if lab:
             if lab.state() == "STOPPED":
+                if module.check_mode:
+                    module.exit_json(changed=True)
                 # wipe existing stopped lab
                 cml.result['changed'] = True
                 lab.wipe(wait=True)

--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -153,12 +153,16 @@ def run_module():
     node = cml.get_node_by_name(lab, cml.params['name'])
     if cml.params['state'] == 'present':
         if node is None:
+            if module.check_mode:
+                module.exit_json(changed=True)
             node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
             cml.result['changed'] = True
     elif cml.params['state'] == 'started':
         if node is None:
             cml.fail_json("Node must be created before it is started")
         if node.state not in ['STARTED', 'BOOTED']:
+            if module.check_mode:
+                module.exit_json(changed=True)
             if node.state == 'DEFINED_ON_CORE' and cml.params['config']:
                 node.config = cml.params['config']
             if cml.params['image_definition']:
@@ -171,6 +175,8 @@ def run_module():
         if node is None:
             cml.fail_json("Node must be created before it is stopped")
         if node.state not in ['STOPPED', 'DEFINED_ON_CORE']:
+            if module.check_mode:
+                module.exit_json(changed=True)
             if cml.params['wait'] is False:
                 lab.wait_for_covergence = False
             node.stop()
@@ -179,6 +185,8 @@ def run_module():
         if node is None:
             cml.fail_json("Node must be created before it is wiped")
         if node.state not in ['DEFINED_ON_CORE']:
+            if module.check_mode:
+                module.exit_json(changed=True)
             node.wipe(wait=cml.params['wait'])
             cml.result['changed'] = True
     cml.exit_json(**cml.result)


### PR DESCRIPTION
Provides check_mode support for both cml_lab and cml_node modules so changed status is returned without actual change happening.

Fixes issue https://github.com/CiscoDevNet/ansible-cml/issues/42

From: https://github.com/CiscoDevNet/ansible-cml/pull/43