### PR TITLE
cml_node | allow prepopulating interfaces before node is started

### DIFF
--- a/plugins/modules/cml_node.py
+++ b/plugins/modules/cml_node.py
@@ -67,6 +67,12 @@ options:
         required: false
         type: str
 
+    populate_interfaces:
+        description: Automatically create a pre-defined number of interfaces on node creation.
+        required: false
+        type: bool
+        default: False
+
     x:
         description: X coordinate on topology canvas
         required: false
@@ -128,6 +134,7 @@ def run_module():
         node_definition=dict(type='str'),
         image_definition=dict(type='str'),
         config=dict(type='str'),
+        populate_interfaces=dict(type='bool', default=False),
         tags=dict(type='list', elements='str'),
         x=dict(type='int'),
         y=dict(type='int'),
@@ -153,7 +160,11 @@ def run_module():
     node = cml.get_node_by_name(lab, cml.params['name'])
     if cml.params['state'] == 'present':
         if node is None:
-            node = lab.create_node(label=cml.params['name'], node_definition=cml.params['node_definition'])
+            node = lab.create_node(
+                label=cml.params['name'],
+                node_definition=cml.params['node_definition'],
+                populate_interfaces=cml.params['populate_interfaces']
+            )
             cml.result['changed'] = True
     elif cml.params['state'] == 'started':
         if node is None:


### PR DESCRIPTION
Without this when we create nodes and not start them we cannot create links as nodes do not have any interfaces pre-created.

It uses existing parameter in Lab.create_node() as visible here:
https://github.com/CiscoDevNet/virl2-client/blob/af60c0b53345937d92402a8c114f9ceca7377a94/virl2_client/models/lab.py#L577-L599

Default behavior of virl2-client is to not prepopulate, default behavior of UI is to prepopulate.
As current behavior was to not prepopulate I have kept it as default.

From: https://github.com/CiscoDevNet/ansible-cml/pull/45